### PR TITLE
add verbose kwarg to load_ckpt

### DIFF
--- a/src/laion_clap/hook.py
+++ b/src/laion_clap/hook.py
@@ -71,7 +71,7 @@ class CLAP_Module(torch.nn.Module):
         )
         return {k: v.squeeze(0) for k, v in result.items()}
 
-    def load_ckpt(self, ckpt = None, model_id = -1):
+    def load_ckpt(self, ckpt = None, model_id = -1, verbose = True):
         """Load the pretrained checkpoint of CLAP model
 
         Parameters
@@ -112,9 +112,10 @@ class CLAP_Module(torch.nn.Module):
         print('Load Checkpoint...')
         ckpt = load_state_dict(ckpt, skip_params=True)
         self.model.load_state_dict(ckpt)
-        param_names = [n for n, p in self.model.named_parameters()]
-        for n in param_names:
-            print(n, "\t", "Loaded" if n in ckpt else "Unloaded")
+        if verbose:
+            param_names = [n for n, p in self.model.named_parameters()]
+            for n in param_names:
+                print(n, "\t", "Loaded" if n in ckpt else "Unloaded")
     
     def get_audio_embedding_from_filelist(self, x, use_tensor=False):
         """get audio embeddings from the audio file list


### PR DESCRIPTION
Added "verbose" kwarg to load_ckpt for optional silencing of param-loading messages.
Reason: Currently, seeing these messages go on for pages and pages, for every node/GPU in the run, can make it hard to read log files.  
Original behavior is retained via default `verbose=True`, i.e. all messages are printed. 
But users optionally can pass in `verbose=False` to suppress notifications of parameter loading.