### PR TITLE
Update hook.py

### DIFF
--- a/src/laion_clap/hook.py
+++ b/src/laion_clap/hook.py
@@ -9,8 +9,8 @@ import os
 import torch
 import librosa
 from clap_module import create_model
-from training.data import get_audio_features
-from training.data import int16_to_float32, float32_to_int16
+from .training.data import get_audio_features
+from .training.data import int16_to_float32, float32_to_int16
 
 from transformers import RobertaTokenizer
 import wget


### PR DESCRIPTION
Add `.` for `training.data`.
Without it, error occurred like below.
*I've installed with `pip install laion-clap`

-----

ImportError                               Traceback (most recent call last)
Cell In[1], line 5
      3 import torch
      4 import glob
----> 5 import laion_clap
      7 import torch
      8 from PIL import Image

File ~/anaconda3/envs/py38/lib/python3.8/site-packages/laion_clap/__init__.py:5
      3 dir_path = os.path.dirname(os.path.abspath(__file__))
      4 sys.path.append(dir_path)
----> 5 from .hook import CLAP_Module

File ~/anaconda3/envs/py38/lib/python3.8/site-packages/laion_clap/hook.py:12
     10 import librosa
     11 from clap_module import create_model
---> 12 from training.data import get_audio_features
     13 from training.data import int16_to_float32, float32_to_int16
     15 from transformers import RobertaTokenizer

ImportError: cannot import name 'get_audio_features' from 'training.data' (/root/anaconda3/envs/py38/lib/python3.8/site-packages/training/data.py)