### PR TITLE
🤗 Transformers compatibility | delete text_branch.embeddings.position_ids key

### DIFF
--- a/src/laion_clap/clap_module/factory.py
+++ b/src/laion_clap/clap_module/factory.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 from copy import deepcopy
 from pathlib import Path
+from packaging import version
 
 import torch
 
@@ -57,9 +58,10 @@ def load_state_dict(checkpoint_path: str, map_location="cpu", skip_params=True):
     if skip_params:
         if next(iter(state_dict.items()))[0].startswith("module"):
             state_dict = {k[7:]: v for k, v in state_dict.items()}
-
-        # removing position_ids to maintain compatibility with latest transformers update
-        del state_dict["text_branch.embeddings.position_ids"]
+        
+        # removing position_ids to maintain compatibility with latest transformers update        
+        if version.parse(transformers.__version__) >= version.parse("4.31.0"): 
+            del state_dict["text_branch.embeddings.position_ids"]
     # for k in state_dict:
     #     if k.startswith('transformer'):
     #         v = state_dict.pop(k)

--- a/src/laion_clap/clap_module/factory.py
+++ b/src/laion_clap/clap_module/factory.py
@@ -57,6 +57,9 @@ def load_state_dict(checkpoint_path: str, map_location="cpu", skip_params=True):
     if skip_params:
         if next(iter(state_dict.items()))[0].startswith("module"):
             state_dict = {k[7:]: v for k, v in state_dict.items()}
+
+        # removing position_ids to maintain compatibility with latest transformers update
+        del state_dict["text_branch.embeddings.position_ids"]
     # for k in state_dict:
     #     if k.startswith('transformer'):
     #         v = state_dict.pop(k)

--- a/src/laion_clap/clap_module/factory.py
+++ b/src/laion_clap/clap_module/factory.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from packaging import version
 
 import torch
+import transformers
 
 from .model import CLAP, convert_weights_to_fp16
 from .openai import load_openai_model


### PR DESCRIPTION
Hi there,

As observed earlier the most recent update to `transformers` has broken `load_state_dict` function in CLAP.
This patch fixes that error. It is effectively removing the `position_ids` key from the text branch. It errors out because of the recent change in transformers https://github.com/huggingface/transformers/pull/24505 :)

This change fixes it. Feel free to let me know if you need any clarification. 🤗

cc: @lukewys 🙏 