### PR TITLE
[F] Fix KeyError when trying to remove position_ids

### DIFF
--- a/src/laion_clap/clap_module/factory.py
+++ b/src/laion_clap/clap_module/factory.py
@@ -61,7 +61,7 @@ def load_state_dict(checkpoint_path: str, map_location="cpu", skip_params=True):
             state_dict = {k[7:]: v for k, v in state_dict.items()}
         
         # removing position_ids to maintain compatibility with latest transformers update        
-        if version.parse(transformers.__version__) >= version.parse("4.31.0"): 
+        if version.parse(transformers.__version__) >= version.parse("4.31.0") and "text_branch.embeddings.position_ids" in state_dict:
             del state_dict["text_branch.embeddings.position_ids"]
     # for k in state_dict:
     #     if k.startswith('transformer'):


### PR DESCRIPTION
You previously added a workaround in your codebase to maintain compatibility with the latest transformers update tries to remove `text_branch.embeddings.position_ids`. However, many people (like me) already implemented a workaround in our own codebase before initializing CLAP, by patching the model ourselves. Your workaround breaks existing workarounds, because models that already have `text_branch.embeddings.position_ids` removed will no longer load.

Here is the precise error that I received:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/tmp/fadtk/fadtk/test/__main__.py", line 36, in <module>
    fad = FrechetAudioDistance(model, audio_load_worker=1, load_model=True)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp/fadtk/fadtk/fad.py", line 130, in __init__
    self.ml.load_model()
  File "/tmp/tmp/fadtk/fadtk/model_loader.py", line 328, in load_model
    self.model.load_ckpt(self.model_file)
  File "/tmp/tmp/fadtk/venv/lib/python3.11/site-packages/laion_clap/hook.py", line 113, in load_ckpt
    ckpt = load_state_dict(ckpt, skip_params=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp/fadtk/venv/lib/python3.11/site-packages/laion_clap/clap_module/factory.py", line 65, in load_state_dict
    del state_dict["text_branch.embeddings.position_ids"]
        ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'text_branch.embeddings.position_ids'
```